### PR TITLE
Fix startup bugs

### DIFF
--- a/init.el
+++ b/init.el
@@ -52,7 +52,7 @@
      ido-ubiquitous
      evil
      evil-visualstar
-     surround
+     evil-surround
      smartparens
      rainbow-delimiters
      magit

--- a/user-lisp/setup-evil.el
+++ b/user-lisp/setup-evil.el
@@ -1,8 +1,8 @@
 (require 'evil)
 (evil-mode 1)
 
-(require 'surround)
-(global-surround-mode 1)
+(require 'evil-surround)
+(global-evil-surround-mode 1)
 
 (require 'evil-visualstar)
 

--- a/user-lisp/setup-tramp.el
+++ b/user-lisp/setup-tramp.el
@@ -5,7 +5,7 @@
 (add-to-list 'exec-path "~/.emacs.d/site-lisp/vagrant-tramp")
 (eval-after-load 'tramp
   '(progn
-     (require 'vagrant-tramp)))
+     (require 'vagrant)))
 
 ;(set-default 'tramp-default-proxies-alist (quote ((".*" "\\`root\\'" "/ssh:%h:"))))
 


### PR DESCRIPTION
I'm running Emacs 24.3.91 on OSX. I had crashes starting-up from two packages being misnamed. It seems that `surround` should be `evil-surroun` and `vagrant-tramp` should be `vagrant`
